### PR TITLE
Improve performance when checking long words for typos

### DIFF
--- a/src/TypoCheckUtils.php
+++ b/src/TypoCheckUtils.php
@@ -108,7 +108,7 @@ class TypoCheckUtils
                 $suggestions = $dictionary[strtolower($word)] ?? null;
                 if ($suggestions === null) {
                     // Analyze anything resembling camelCase, CamelCase, or snake_case
-                    if (preg_match('/(?:[a-z].*[A-Z]|_)/', $word)) {
+                    if (preg_match('/(?:[a-z][A-Z]|_)/', $word)) {
                         preg_match_all('/[a-z]+|[A-Z](?:[a-z]+|[A-Z]+(?![a-z]))/', $word, $matches);
                         if (count($matches[0]) >= 2) {
                             foreach ($matches[0] as $inner_word) {


### PR DESCRIPTION
Fix backtracking in this regex that harmed performance when there
were long strings of lowercase letters without uppercase or underscores.
